### PR TITLE
feat(addon): add helm release install control variable

### DIFF
--- a/modules/addon/helm.tf
+++ b/modules/addon/helm.tf
@@ -1,5 +1,5 @@
 resource "helm_release" "this" {
-  count            = var.enabled == true && var.argo_enabled == false ? 1 : 0
+  count            = var.enabled == true && var.helm_enabled == true && var.argo_enabled == false ? 1 : 0
   chart            = var.helm_chart_name
   create_namespace = var.helm_create_namespace
   namespace        = var.namespace

--- a/modules/addon/variables.tf
+++ b/modules/addon/variables.tf
@@ -6,6 +6,12 @@ variable "enabled" {
 
 # ================ common variables (required) ================
 
+variable "helm_enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent installation of the module via Helm release. Defaults to `true`."
+}
+
 variable "helm_chart_name" {
   type        = string
   default     = null


### PR DESCRIPTION
# Description

There might be cases installation via Helm might be done in 2 steps - 1st other resources, 2nd Helm release. This feature originates from one of our addons as community enhancement.

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->

