### PR TITLE
feat(modules/addon): add support for argo app operation

### DIFF
--- a/modules/addon/argo.tf
+++ b/modules/addon/argo.tf
@@ -44,21 +44,26 @@ locals {
 resource "kubernetes_manifest" "this" {
   count = var.enabled == true && var.argo_enabled == true && var.argo_helm_enabled == false ? 1 : 0
 
-  manifest = {
-    apiVersion = var.argo_apiversion
-    kind       = "Application"
-    metadata = merge(
-      local.argo_application_metadata,
-      {
-        name      = local.argo_application_name
-        namespace = var.argo_namespace
-      },
-    )
-    spec = merge(
-      local.argo_application_spec,
-      var.argo_spec
-    )
-  }
+  manifest = merge(
+    {
+      apiVersion = var.argo_apiversion
+      kind       = "Application"
+      metadata = merge(
+        local.argo_application_metadata,
+        {
+          name      = local.argo_application_name
+          namespace = var.argo_namespace
+        },
+      )
+      spec = merge(
+        local.argo_application_spec,
+        var.argo_spec
+      )
+    },
+    length(var.argo_operation) > 0 ? {
+      operation = var.argo_operation
+    } : {},
+  )
 
   computed_fields = var.argo_kubernetes_manifest_computed_fields
 

--- a/modules/addon/variables.tf
+++ b/modules/addon/variables.tf
@@ -182,6 +182,12 @@ variable "argo_spec" {
   description = "ArgoCD Application spec configuration. Override or create additional spec parameters."
 }
 
+variable "argo_operation" {
+  type        = any
+  default     = {}
+  description = "ArgoCD Application manifest operation parameter."
+}
+
 variable "argo_helm_values" {
   type        = string
   default     = ""


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

This pull request introduces enhancements to the ArgoCD Application manifest configuration in the Terraform module. The main changes include adding support for an optional `operation` parameter and updating the `manifest` structure to conditionally include this parameter. This works only for `kubernetes_manifest` resource, NOT `helm_release`.

The `operation` parameter might be useful in cases, when ArgoCD Application is installed with Terraform `kubernetes_manifest` which might result in inconsistent plan when using automatic Application sync. `operation` parameter enables explicit Application sync after the Terraform changes are properly applied mitigating inconsistent plan issue, ie. https://github.com/hashicorp/terraform-provider-kubernetes/issues/2367#issuecomment-2109056758.

Key changes:

* Updated `manifest` structure in `modules/addon/argo.tf` to use the `merge` function and conditionally include the `operation` parameter if it is provided. [[1]](diffhunk://#diff-3bb9b8e0a43f60bf5118e3fe9137c45b42bea1096e30b32eb418a7890be20cc2L35-R36) [[2]](diffhunk://#diff-3bb9b8e0a43f60bf5118e3fe9137c45b42bea1096e30b32eb418a7890be20cc2L49-R54)
* Added a new variable `argo_operation` in `modules/addon/variables.tf` to allow specifying the `operation` parameter for the ArgoCD application manifest.

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->

- Install App without specifying `argo_operation` and checked if App won't sync
- Install App with specifying `argo_operation` and checked if App will sync