### PR TITLE
feat(modules/addon): add support for argo kustomize/raw source

### DIFF
--- a/modules/addon/argo-helm.tf
+++ b/modules/addon/argo-helm.tf
@@ -15,7 +15,7 @@ data "utils_deep_merge_yaml" "argo_helm_values" {
       apiVersion = var.argo_apiversion
     }),
     yamlencode({
-      spec = local.argo_application_values
+      spec = local.argo_application_spec
     }),
     yamlencode({
       spec = var.argo_spec
@@ -30,7 +30,7 @@ resource "helm_release" "argo_application" {
   count = local.helm_argo_application_enabled ? 1 : 0
 
   chart     = "${path.module}/helm/argocd-application"
-  name      = var.helm_release_name
+  name      = local.argo_application_name
   namespace = var.argo_namespace
 
   max_history = var.helm_release_max_history
@@ -42,7 +42,7 @@ resource "kubernetes_role" "helm_argo_application_wait" {
   count = local.helm_argo_application_wait_enabled ? 1 : 0
 
   metadata {
-    name        = "${var.helm_release_name}-argo-application-wait"
+    name        = "${local.argo_application_name}-argo-application-wait"
     namespace   = var.argo_namespace
     labels      = local.argo_application_metadata.labels
     annotations = local.argo_application_metadata.annotations
@@ -59,7 +59,7 @@ resource "kubernetes_role_binding" "helm_argo_application_wait" {
   count = local.helm_argo_application_wait_enabled ? 1 : 0
 
   metadata {
-    name        = "${var.helm_release_name}-argo-application-wait"
+    name        = "${local.argo_application_name}-argo-application-wait"
     namespace   = var.argo_namespace
     labels      = local.argo_application_metadata.labels
     annotations = local.argo_application_metadata.annotations
@@ -82,7 +82,7 @@ resource "kubernetes_service_account" "helm_argo_application_wait" {
   count = local.helm_argo_application_wait_enabled ? 1 : 0
 
   metadata {
-    name        = "${var.helm_release_name}-argo-application-wait"
+    name        = "${local.argo_application_name}-argo-application-wait"
     namespace   = var.argo_namespace
     labels      = local.argo_application_metadata.labels
     annotations = local.argo_application_metadata.annotations
@@ -93,7 +93,7 @@ resource "kubernetes_job" "helm_argo_application_wait" {
   count = local.helm_argo_application_wait_enabled ? 1 : 0
 
   metadata {
-    generate_name = "${var.helm_release_name}-argo-application-wait-"
+    generate_name = "${local.argo_application_name}-argo-application-wait-"
     namespace     = var.argo_namespace
     labels        = local.argo_application_metadata.labels
     annotations   = local.argo_application_metadata.annotations
@@ -124,7 +124,7 @@ resource "kubernetes_job" "helm_argo_application_wait" {
               "--timeout=${var.argo_helm_wait_timeout}",
               "--v=1", # https://kubernetes.io/docs/reference/kubectl/quick-reference/#kubectl-output-verbosity-and-debugging
               "application.argoproj.io",
-              var.helm_release_name
+              local.argo_application_name
             ]
           }
         }

--- a/modules/addon/validations.tf
+++ b/modules/addon/validations.tf
@@ -1,0 +1,26 @@
+resource "terraform_data" "validations" {
+  lifecycle {
+    precondition {
+      condition = !local.argo_application_source_helm_enabled || (
+        var.helm_repo_url != null
+        && var.helm_chart_name != null
+        && var.helm_chart_version != null
+        && var.helm_release_name != null
+      )
+      error_message = "The `helm_repo_url`, `helm_chart_name`, `helm_chart_version`, and `helm_release_name` variables must be set when argo_source_type is set to `helm`."
+    }
+
+    precondition {
+      condition = (
+        !local.argo_application_source_kustomize_enabled
+        && !local.argo_application_source_directory_enabled
+        ) || (
+        var.argo_source_repo_url != null
+        && var.argo_source_path != null
+        && var.argo_source_target_revision != null
+        && var.argo_name != null
+      )
+      error_message = "The `argo_source_repo_url`, `argo_source_path`, `argo_source_target_revision` and `argo_name` variables must be set when argo_source_type is set to `kustomize` or `directory`."
+    }
+  }
+}

--- a/modules/addon/variables.tf
+++ b/modules/addon/variables.tf
@@ -60,7 +60,7 @@ variable "values" {
 variable "argo_name" {
   type        = string
   default     = null
-  description = "Name of the ArgoCD Application. Required if `argo_source_type` is set to `kustomize` or `directory`."
+  description = "Name of the ArgoCD Application. Required if `argo_source_type` is set to `kustomize` or `directory`.  If `argo_source_type` is set to `helm`, ArgoCD Application name will equal `helm_release_name`."
 }
 
 variable "argo_namespace" {

--- a/modules/addon/variables.tf
+++ b/modules/addon/variables.tf
@@ -12,22 +12,26 @@ variable "helm_enabled" {
 
 variable "helm_chart_name" {
   type        = string
-  description = "Helm chart name to be installed (required)."
+  default     = null
+  description = "Helm chart name to be installed. Required if `argo_source_type` is set to `helm`."
 }
 
 variable "helm_chart_version" {
   type        = string
-  description = "Version of the Helm chart (required)."
+  default     = null
+  description = "Version of the Helm chart. Required if `argo_source_type` is set to `helm`."
 }
 
 variable "helm_release_name" {
   type        = string
-  description = "Helm release name (required)."
+  default     = null
+  description = "Helm release name. Required if `argo_source_type` is set to `helm`."
 }
 
 variable "helm_repo_url" {
   type        = string
-  description = "Helm repository (required)."
+  default     = null
+  description = "Helm repository. Required if `argo_source_type` is set to `helm`."
 }
 
 variable "helm_create_namespace" {
@@ -44,7 +48,7 @@ variable "namespace" {
 variable "settings" {
   type        = map(any)
   default     = {}
-  description = "Additional Helm sets which will be passed to the Helm chart values."
+  description = "Additional Helm sets which will be passed to the Helm chart values or Kustomize or directory configuration which will be passed to ArgoCD Application source."
 }
 
 variable "values" {
@@ -53,10 +57,16 @@ variable "values" {
   description = "Additional YAML encoded values which will be passed to the Helm chart."
 }
 
+variable "argo_name" {
+  type        = string
+  default     = null
+  description = "Name of the ArgoCD Application. Required if `argo_source_type` is set to `kustomize` or `directory`."
+}
+
 variable "argo_namespace" {
   type        = string
   default     = "argo"
-  description = "Namespace to deploy ArgoCD Application CRD to."
+  description = "Namespace to deploy ArgoCD Application to."
 }
 
 variable "argo_enabled" {
@@ -99,6 +109,35 @@ variable "argo_helm_wait_kubectl_version" {
   type        = string
   default     = "1.32.3" # renovate: datasource=github-releases depName=kubernetes/kubernetes
   description = "Version of kubectl to use for ArgoCD Application wait job."
+}
+
+variable "argo_source_type" {
+  type        = string
+  default     = "helm"
+  description = "Source type for ArgoCD Application. Can be either `helm`, `kustomize`, or `directory`."
+
+  validation {
+    condition     = contains(["helm", "kustomize", "directory"], var.argo_source_type)
+    error_message = "Source type must be either `helm`, `kustomize`, or `directory`."
+  }
+}
+
+variable "argo_source_repo_url" {
+  type        = string
+  default     = null
+  description = "ArgoCD Application source repo URL. Required if `argo_source_type` is set to `kustomize` or `directory`."
+}
+
+variable "argo_source_target_revision" {
+  type        = string
+  default     = null
+  description = "ArgoCD Application source target revision. Required if `argo_source_type` is set to `kustomize` or `directory`."
+}
+
+variable "argo_source_path" {
+  type        = string
+  default     = null
+  description = "ArgoCD Application source path. Required if `argo_source_type` is set to `kustomize` or `directory`."
 }
 
 variable "argo_destination_server" {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

This pull request includes several changes to the Argo Helm module to support different source types for ArgoCD applications. The changes introduce new variables, update existing resources, and add validation to ensure proper configuration based on the source type.

### Support for Different Source Types:

* [`modules/addon/argo.tf`](diffhunk://#diff-3bb9b8e0a43f60bf5118e3fe9137c45b42bea1096e30b32eb418a7890be20cc2R2-R33): Introduced local variables to enable different source types (`helm`, `kustomize`, `directory`) and updated the `argo_application_spec` to handle these source types.

### Updates to Resource Names and Specifications:

* [`modules/addon/argo-helm.tf`](diffhunk://#diff-96e883b1a1f8b8f6308ddb242c74608d40b6d25b3e532a8222a315778d98eecaL33-R33): Updated various resource definitions to use `local.argo_application_name` instead of `var.helm_release_name` for consistent naming across different source types. [[1]](diffhunk://#diff-96e883b1a1f8b8f6308ddb242c74608d40b6d25b3e532a8222a315778d98eecaL33-R33) [[2]](diffhunk://#diff-96e883b1a1f8b8f6308ddb242c74608d40b6d25b3e532a8222a315778d98eecaL45-R45) [[3]](diffhunk://#diff-96e883b1a1f8b8f6308ddb242c74608d40b6d25b3e532a8222a315778d98eecaL62-R62) [[4]](diffhunk://#diff-96e883b1a1f8b8f6308ddb242c74608d40b6d25b3e532a8222a315778d98eecaL85-R85) [[5]](diffhunk://#diff-96e883b1a1f8b8f6308ddb242c74608d40b6d25b3e532a8222a315778d98eecaL96-R96) [[6]](diffhunk://#diff-96e883b1a1f8b8f6308ddb242c74608d40b6d25b3e532a8222a315778d98eecaL127-R127)

### Validation for Source Type Configuration:

* [`modules/addon/validations.tf`](diffhunk://#diff-a4a630b8465beb946c2514847c8f99a9abc660444a2c936dc1b3d2e71ba4652bR1-R26): Added preconditions to validate that necessary variables are set based on the selected `argo_source_type`.

### New and Updated Variables:

* [`modules/addon/variables.tf`](diffhunk://#diff-7093adca6d2acf48477c77ac15bde2761de4d50a1aa8c2d15b1296c2d3d0b756L15-R34): Added new variables for `argo_source_type`, `argo_source_repo_url`, `argo_source_target_revision`, `argo_source_path`, and `argo_name`. Updated descriptions and defaults for existing Helm-related variables to reflect their conditional requirement based on `argo_source_type`. [[1]](diffhunk://#diff-7093adca6d2acf48477c77ac15bde2761de4d50a1aa8c2d15b1296c2d3d0b756L15-R34) [[2]](diffhunk://#diff-7093adca6d2acf48477c77ac15bde2761de4d50a1aa8c2d15b1296c2d3d0b756L47-R51) [[3]](diffhunk://#diff-7093adca6d2acf48477c77ac15bde2761de4d50a1aa8c2d15b1296c2d3d0b756R60-R69) [[4]](diffhunk://#diff-7093adca6d2acf48477c77ac15bde2761de4d50a1aa8c2d15b1296c2d3d0b756R114-R142)

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->

- Deployed ArgoCD App using kuberenetes_manifest Argo install with Helm source and Kustomize
- Deployed ArgoCD App using helm_release Helm Argo install with Helm source and Kustomize