### PR TITLE
feat(modules/addon): add skipCrds parameter to helm configuration

### DIFF
--- a/modules/addon/argo.tf
+++ b/modules/addon/argo.tf
@@ -13,6 +13,7 @@ locals {
     helm = local.argo_application_source_helm_enabled ? merge(
       {
         releaseName = var.helm_release_name
+        skipCrds    = var.helm_skip_crds
         values      = var.values
       },
       length(var.settings) > 0 ? {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

This pull request includes a change to the `modules/addon/argo.tf` file to add a new configuration option for Helm charts.

Configuration enhancements:

* [`modules/addon/argo.tf`](diffhunk://#diff-3bb9b8e0a43f60bf5118e3fe9137c45b42bea1096e30b32eb418a7890be20cc2R16): Added the `skipCrds` option to the Helm configuration to allow skipping the installation of CRDs when deploying Helm charts.

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->

Tested with Traefik Ingress addon installation