### PR TITLE
feat(pod identity): add module for pod identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ See [basic example](examples/basic) for further information.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_addon"></a> [addon](#module\_addon) | git::https://github.com/lablabs/terraform-aws-eks-universal-addon.git//modules/addon | v0.0.14 |
-| <a name="module_addon-irsa"></a> [addon-irsa](#module\_addon-irsa) | git::https://github.com/lablabs/terraform-aws-eks-universal-addon.git//modules/addon-irsa | v0.0.14 |
-| <a name="module_addon-oidc"></a> [addon-oidc](#module\_addon-oidc) | git::https://github.com/lablabs/terraform-aws-eks-universal-addon.git//modules/addon-oidc | v0.0.14 |
+| <a name="module_addon"></a> [addon](#module\_addon) | ./modules/addon | n/a |
+| <a name="module_addon-irsa"></a> [addon-irsa](#module\_addon-irsa) | ./modules/addon-irsa | n/a |
+| <a name="module_addon-oidc"></a> [addon-oidc](#module\_addon-oidc) | ./modules/addon-oidc | n/a |
+| <a name="module_addon-pod-identity"></a> [addon-pod-identity](#module\_addon-pod-identity) | ./modules/addon-pod-identity | n/a |
 ## Resources
 
 | Name | Type |
@@ -64,6 +65,7 @@ See [basic example](examples/basic) for further information.
 
 | Name | Description | Type |
 |------|-------------|------|
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` |
 | <a name="input_argo_apiversion"></a> [argo\_apiversion](#input\_argo\_apiversion) | ArgoCD Application apiVersion. Defaults to `argoproj.io/v1alpha1`. | `string` |
 | <a name="input_argo_destination_server"></a> [argo\_destination\_server](#input\_argo\_destination\_server) | Destination server for ArgoCD Application. Defaults to `https://kubernetes.default.svc`. | `string` |
 | <a name="input_argo_enabled"></a> [argo\_enabled](#input\_argo\_enabled) | If set to `true`, the module will be deployed as ArgoCD Application, otherwise it will be deployed as a Helm release. Defaults to `false`. | `bool` |
@@ -158,6 +160,20 @@ See [basic example](examples/basic) for further information.
 | <a name="input_oidc_role_name"></a> [oidc\_role\_name](#input\_oidc\_role\_name) | OIDC role name. The value is prefixed by `oidc_role_name_prefix`. Either `oidc_role_name` or `oidc_role_name_prefix` must be set. Defaults to `""`. | `string` |
 | <a name="input_oidc_role_name_prefix"></a> [oidc\_role\_name\_prefix](#input\_oidc\_role\_name\_prefix) | OIDC role name prefix. Either `oidc_role_name_prefix` or `oidc_role_name` must be set. Defaults to `""`. | `string` |
 | <a name="input_oidc_tags"></a> [oidc\_tags](#input\_oidc\_tags) | OIDC resources tags. Defaults to `{}`. | `map(string)` |
+| <a name="input_pi_rbac_create"></a> [pi\_rbac\_create](#input\_pi\_rbac\_create) | Whether to create and use RBAC resources. Defaults to `true`. | `bool` |
+| <a name="input_pi_service_account_create"></a> [pi\_service\_account\_create](#input\_pi\_service\_account\_create) | Whether to create Service Account. Defaults to `true`. | `bool` |
+| <a name="input_pi_service_account_name"></a> [pi\_service\_account\_name](#input\_pi\_service\_account\_name) | The Kubernetes Service Account name. Defaults to the addon name. Defaults to `""`. | `string` |
+| <a name="input_pi_service_account_namespace"></a> [pi\_service\_account\_namespace](#input\_pi\_service\_account\_namespace) | The Kubernetes Service Account namespace. Defaults to the addon namespace. Defaults to `""`. | `string` |
+| <a name="input_pod_identity_additional_policies"></a> [pod\_identity\_additional\_policies](#input\_pod\_identity\_additional\_policies) | Map of the additional policies to be attached to pod identity role. Where key is arbitrary id and value is policy ARN. Defaults to `{}`. | `map(string)` |
+| <a name="input_pod_identity_assume_role_arns"></a> [pod\_identity\_assume\_role\_arns](#input\_pod\_identity\_assume\_role\_arns) | List of ARNs assumable by the pod identity role. Applied only if `pod_identity_assume_role_enabled` is `true`. Defaults to `[]`. | `list(string)` |
+| <a name="input_pod_identity_assume_role_enabled"></a> [pod\_identity\_assume\_role\_enabled](#input\_pod\_identity\_assume\_role\_enabled) | Whether pod identity is allowed to assume role defined by `pod_identity_assume_role_arn`. Mutually exclusive with `pod_identity_policy_enabled`. Defaults to `false`. | `bool` |
+| <a name="input_pod_identity_permissions_boundary"></a> [pod\_identity\_permissions\_boundary](#input\_pod\_identity\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the pod identity role. Defaults to `null`. | `string` |
+| <a name="input_pod_identity_policy"></a> [pod\_identity\_policy](#input\_pod\_identity\_policy) | AWS IAM policy JSON document to be attached to the pod identity role. Applied only if `pod_identity_policy_enabled` is `true`. Defaults to `""`. | `string` |
+| <a name="input_pod_identity_policy_enabled"></a> [pod\_identity\_policy\_enabled](#input\_pod\_identity\_policy\_enabled) | Whether to create IAM policy specified by `pod_identity_policy`. Mutually exclusive with `pod_identity_assume_role_enabled`. Defaults to `false`. | `bool` |
+| <a name="input_pod_identity_role_create"></a> [pod\_identity\_role\_create](#input\_pod\_identity\_role\_create) | Whether to create pod identity role and annotate Service Account. Defaults to `true`. | `bool` |
+| <a name="input_pod_identity_role_name"></a> [pod\_identity\_role\_name](#input\_pod\_identity\_role\_name) | Pod identity role name. The value is prefixed by `pod_identity_role_name_prefix`. Either `pod_identity_role_name` or `pod_identity_role_name_prefix` must be set. Defaults to `""`. | `string` |
+| <a name="input_pod_identity_role_name_prefix"></a> [pod\_identity\_role\_name\_prefix](#input\_pod\_identity\_role\_name\_prefix) | Pod identity role name prefix. Either `pod_identity_role_name_prefix` or `pod_identity_role_name` must be set. Defaults to `""`. | `string` |
+| <a name="input_pod_identity_tags"></a> [pod\_identity\_tags](#input\_pod\_identity\_tags) | Pod identity resources tags. Defaults to `{}`. | `map(string)` |
 | <a name="input_rbac_create"></a> [rbac\_create](#input\_rbac\_create) | Whether to create and use RBAC resources. Defaults to `true`. | `bool` |
 | <a name="input_service_account_create"></a> [service\_account\_create](#input\_service\_account\_create) | Whether to create Service Account. Defaults to `true`. | `bool` |
 | <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The Kubernetes Service Account name. Defaults to the addon name. Defaults to `""`. | `string` |
@@ -171,6 +187,7 @@ See [basic example](examples/basic) for further information.
 | <a name="output_addon"></a> [addon](#output\_addon) | The addon module outputs |
 | <a name="output_addon_irsa"></a> [addon\_irsa](#output\_addon\_irsa) | The addon IRSA module outputs |
 | <a name="output_addon_oidc"></a> [addon\_oidc](#output\_addon\_oidc) | The addon oidc module outputs |
+| <a name="output_addon_pod_identity"></a> [addon\_pod\_identity](#output\_addon\_pod\_identity) | The addon pod identity module outputs |
 ## Contributing and reporting issues
 
 Feel free to create an issue in this repository if you have questions, suggestions or feature requests.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [basic example](examples/basic) for further information.
 |------|------|
 | [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 > [!IMPORTANT]
-> Variables defined in [variables-addon[-irsa|oidc].tf](variables-addon.tf) defaults to `null` to have them overridable by the addon configuration defined though the [`local.addon[_irsa|oidc].*`](main.tf) local variable with the default values defined in [addon[-irsa|oidc].tf](addon.tf).
+> Variables defined in [variables-addon[-irsa|-oidc|pod-identity].tf](variables-addon.tf) defaults to `null` to have them overridable by the addon configuration defined though the [`local.addon[_irsa|_oidc|_pod_identity].*`](main.tf) local variable with the default values defined in [addon[-irsa|-oidc|-pod-identity].tf](addon.tf).
 ## Inputs
 
 | Name | Description | Type |
@@ -160,10 +160,6 @@ See [basic example](examples/basic) for further information.
 | <a name="input_oidc_role_name"></a> [oidc\_role\_name](#input\_oidc\_role\_name) | OIDC role name. The value is prefixed by `oidc_role_name_prefix`. Either `oidc_role_name` or `oidc_role_name_prefix` must be set. Defaults to `""`. | `string` |
 | <a name="input_oidc_role_name_prefix"></a> [oidc\_role\_name\_prefix](#input\_oidc\_role\_name\_prefix) | OIDC role name prefix. Either `oidc_role_name_prefix` or `oidc_role_name` must be set. Defaults to `""`. | `string` |
 | <a name="input_oidc_tags"></a> [oidc\_tags](#input\_oidc\_tags) | OIDC resources tags. Defaults to `{}`. | `map(string)` |
-| <a name="input_pi_rbac_create"></a> [pi\_rbac\_create](#input\_pi\_rbac\_create) | Whether to create and use RBAC resources. Defaults to `true`. | `bool` |
-| <a name="input_pi_service_account_create"></a> [pi\_service\_account\_create](#input\_pi\_service\_account\_create) | Whether to create Service Account. Defaults to `true`. | `bool` |
-| <a name="input_pi_service_account_name"></a> [pi\_service\_account\_name](#input\_pi\_service\_account\_name) | The Kubernetes Service Account name. Defaults to the addon name. Defaults to `""`. | `string` |
-| <a name="input_pi_service_account_namespace"></a> [pi\_service\_account\_namespace](#input\_pi\_service\_account\_namespace) | The Kubernetes Service Account namespace. Defaults to the addon namespace. Defaults to `""`. | `string` |
 | <a name="input_pod_identity_additional_policies"></a> [pod\_identity\_additional\_policies](#input\_pod\_identity\_additional\_policies) | Map of the additional policies to be attached to pod identity role. Where key is arbitrary id and value is policy ARN. Defaults to `{}`. | `map(string)` |
 | <a name="input_pod_identity_assume_role_arns"></a> [pod\_identity\_assume\_role\_arns](#input\_pod\_identity\_assume\_role\_arns) | List of ARNs assumable by the pod identity role. Applied only if `pod_identity_assume_role_enabled` is `true`. Defaults to `[]`. | `list(string)` |
 | <a name="input_pod_identity_assume_role_enabled"></a> [pod\_identity\_assume\_role\_enabled](#input\_pod\_identity\_assume\_role\_enabled) | Whether pod identity is allowed to assume role defined by `pod_identity_assume_role_arn`. Mutually exclusive with `pod_identity_policy_enabled`. Defaults to `false`. | `bool` |

--- a/addon-irsa.tf
+++ b/addon-irsa.tf
@@ -2,7 +2,8 @@
 module "addon-irsa" {
   for_each = local.addon_irsa
 
-  source = "git::https://github.com/lablabs/terraform-aws-eks-universal-addon.git//modules/addon-irsa?ref=v0.0.14"
+  #source = "git::https://github.com/lablabs/terraform-aws-eks-universal-addon.git//modules/addon-irsa?ref=v0.0.14"
+  source = "./modules/addon-irsa"
 
   enabled = var.enabled
 

--- a/addon-oidc.tf
+++ b/addon-oidc.tf
@@ -2,7 +2,7 @@
 module "addon-oidc" {
   for_each = local.addon_oidc
 
-  source = "git::https://github.com/lablabs/terraform-aws-eks-universal-addon.git//modules/addon-oidc?ref=v0.0.14"
+  source = "./modules/addon-oidc"
 
   enabled = var.enabled
 

--- a/addon-pod-identity.tf
+++ b/addon-pod-identity.tf
@@ -15,7 +15,7 @@ module "addon-pod-identity" {
   service_account_namespace = var.pi_service_account_namespace != null ? var.pi_service_account_namespace : try(each.value.pi_service_account_namespace, local.addon_namespace)
 
   pod_identity_role_create      = var.pod_identity_role_create != null ? var.pod_identity_role_create : try(each.value.pod_identity_role_create, true)
-  pod_identity_role_name_prefix = var.pod_identity_role_name_prefix != null ? var.pod_identity_role_name_prefix : try(each.value.pod_identity_role_name_prefix, "${each.key}-pod-identity")
+  pod_identity_role_name_prefix = var.pod_identity_role_name_prefix != null ? var.pod_identity_role_name_prefix : try(each.value.pod_identity_role_name_prefix, "${each.key}-epi")
   pod_identity_role_name        = var.pod_identity_role_name != null ? var.pod_identity_role_name : try(each.value.pod_identity_role_name, local.addon_name)
 
   pod_identity_policy_enabled       = var.pod_identity_policy_enabled != null ? var.pod_identity_policy_enabled : try(each.value.pod_identity_policy_enabled, false)

--- a/addon-pod-identity.tf
+++ b/addon-pod-identity.tf
@@ -15,7 +15,7 @@ module "addon-pod-identity" {
   service_account_namespace = var.pi_service_account_namespace != null ? var.pi_service_account_namespace : try(each.value.pi_service_account_namespace, local.addon_namespace)
 
   pod_identity_role_create      = var.pod_identity_role_create != null ? var.pod_identity_role_create : try(each.value.pod_identity_role_create, true)
-  pod_identity_role_name_prefix = var.pod_identity_role_name_prefix != null ? var.pod_identity_role_name_prefix : try(each.value.pod_identity_role_name_prefix, "${each.key}-pod_identity")
+  pod_identity_role_name_prefix = var.pod_identity_role_name_prefix != null ? var.pod_identity_role_name_prefix : try(each.value.pod_identity_role_name_prefix, "${each.key}-pod-identity")
   pod_identity_role_name        = var.pod_identity_role_name != null ? var.pod_identity_role_name : try(each.value.pod_identity_role_name, local.addon_name)
 
   pod_identity_policy_enabled       = var.pod_identity_policy_enabled != null ? var.pod_identity_policy_enabled : try(each.value.pod_identity_policy_enabled, false)

--- a/addon-pod-identity.tf
+++ b/addon-pod-identity.tf
@@ -8,11 +8,11 @@ module "addon-pod-identity" {
 
   cluster_name = var.cluster_name != null ? var.cluster_name : try(each.value.cluster_name, null)
   # TODO: Do I need this?
-  rbac_create = var.pi_rbac_create != null ? var.pi_rbac_create : try(each.value.pi_rbac_create, true)
+  rbac_create = var.rbac_create != null ? var.rbac_create : try(each.value.rbac_create, true)
   # TODO: Do I need this?
-  service_account_create    = var.pi_service_account_create != null ? var.pi_service_account_create : try(each.value.pi_service_account_create, true)
-  service_account_name      = var.pi_service_account_name != null ? var.pi_service_account_name : try(each.value.pi_service_account_name, each.key)
-  service_account_namespace = var.pi_service_account_namespace != null ? var.pi_service_account_namespace : try(each.value.pi_service_account_namespace, local.addon_namespace)
+  service_account_create    = var.service_account_create != null ? var.service_account_create : try(each.value.service_account_create, true)
+  service_account_name      = var.service_account_name != null ? var.service_account_name : try(each.value.service_account_name, each.key)
+  service_account_namespace = var.service_account_namespace != null ? var.service_account_namespace : try(each.value.service_account_namespace, local.addon_namespace)
 
   pod_identity_role_create      = var.pod_identity_role_create != null ? var.pod_identity_role_create : try(each.value.pod_identity_role_create, true)
   pod_identity_role_name_prefix = var.pod_identity_role_name_prefix != null ? var.pod_identity_role_name_prefix : try(each.value.pod_identity_role_name_prefix, "${each.key}-epi")

--- a/addon-pod-identity.tf
+++ b/addon-pod-identity.tf
@@ -1,0 +1,34 @@
+# IMPORTANT: This file is synced with the "terraform-aws-eks-universal-addon" module. Any changes to this file might be overwritten upon the next release of that module.
+module "addon-pod-identity" {
+  for_each = local.addon_pod_identity
+
+  source = "./modules/addon-pod-identity"
+
+  enabled = var.enabled
+
+  cluster_name = var.cluster_name != null ? var.cluster_name : try(each.value.cluster_name, null)
+  # TODO: Do I need this?
+  rbac_create = var.pi_rbac_create != null ? var.pi_rbac_create : try(each.value.pi_rbac_create, true)
+  # TODO: Do I need this?
+  service_account_create    = var.pi_service_account_create != null ? var.pi_service_account_create : try(each.value.pi_service_account_create, true)
+  service_account_name      = var.pi_service_account_name != null ? var.pi_service_account_name : try(each.value.pi_service_account_name, each.key)
+  service_account_namespace = var.pi_service_account_namespace != null ? var.pi_service_account_namespace : try(each.value.pi_service_account_namespace, local.addon_namespace)
+
+  pod_identity_role_create      = var.pod_identity_role_create != null ? var.pod_identity_role_create : try(each.value.pod_identity_role_create, true)
+  pod_identity_role_name_prefix = var.pod_identity_role_name_prefix != null ? var.pod_identity_role_name_prefix : try(each.value.pod_identity_role_name_prefix, "${each.key}-pod_identity")
+  pod_identity_role_name        = var.pod_identity_role_name != null ? var.pod_identity_role_name : try(each.value.pod_identity_role_name, local.addon_name)
+
+  pod_identity_policy_enabled       = var.pod_identity_policy_enabled != null ? var.pod_identity_policy_enabled : try(each.value.pod_identity_policy_enabled, false)
+  pod_identity_policy               = var.pod_identity_policy != null ? var.pod_identity_policy : try(each.value.pod_identity_policy, "")
+  pod_identity_assume_role_enabled  = var.pod_identity_assume_role_enabled != null ? var.pod_identity_assume_role_enabled : try(each.value.pod_identity_assume_role_enabled, false)
+  pod_identity_assume_role_arns     = var.pod_identity_assume_role_arns != null ? var.pod_identity_assume_role_arns : try(each.value.pod_identity_assume_role_arns, [])
+  pod_identity_permissions_boundary = var.pod_identity_permissions_boundary != null ? var.pod_identity_permissions_boundary : try(each.value.pod_identity_permissions_boundary, null)
+  pod_identity_additional_policies  = var.pod_identity_additional_policies != null ? var.pod_identity_additional_policies : try(each.value.pod_identity_additional_policies, tomap({}))
+
+  pod_identity_tags = var.pod_identity_tags != null ? var.pod_identity_tags : try(each.value.pod_identity_tags, tomap({}))
+}
+
+output "addon_pod_identity" {
+  description = "The addon pod identity module outputs"
+  value       = module.addon-pod-identity
+}

--- a/addon.tf
+++ b/addon.tf
@@ -11,7 +11,8 @@ locals {
 }
 
 module "addon" {
-  source = "git::https://github.com/lablabs/terraform-aws-eks-universal-addon.git//modules/addon?ref=v0.0.14"
+  #source = "git::https://github.com/lablabs/terraform-aws-eks-universal-addon.git//modules/addon?ref=v0.0.14"
+  source = "./modules/addon"
 
   enabled = var.enabled
 

--- a/docs/.inputs.md
+++ b/docs/.inputs.md
@@ -1,2 +1,2 @@
 > [!IMPORTANT]
-> Variables defined in [variables-addon[-irsa|oidc].tf](variables-addon.tf) defaults to `null` to have them overridable by the addon configuration defined though the [`local.addon[_irsa|oidc].*`](main.tf) local variable with the default values defined in [addon[-irsa|oidc].tf](addon.tf).
+> Variables defined in [variables-addon[-irsa|-oidc|pod-identity].tf](variables-addon.tf) defaults to `null` to have them overridable by the addon configuration defined though the [`local.addon[_irsa|_oidc|_pod_identity].*`](main.tf) local variable with the default values defined in [addon[-irsa|-oidc|-pod-identity].tf](addon.tf).

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,13 @@ locals {
     }
   }
 
+  # FIXME config: add addon pod identity configuration here or remove if not needed
+  addon_pod_identity = {
+    (local.addon.name) = {
+      # FIXME config: add default pod identity overrides here or leave empty if not needed, but make sure to keep at least one key
+    }
+  }
+
   addon_values = yamlencode({
     # FIXME config: add default values here
   })

--- a/modules/addon-pod-identity/.terraform.lock.hcl
+++ b/modules/addon-pod-identity/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.83.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:8KI8wFWW2iPYVMyNGI75bxgmwy8MjZk4G6Quut5H7x8=",
+    "h1:Yy3K7R7881H72rQDzG6qjZVkrWA6DGJzfE21TionY7w=",
+    "h1:vInFMDq9oMs53/i+7IU8hZgmTLhFfng8L8kbuALZxSI=",
+    "zh:0313253c78f195973752c4d1f62bfdd345a9c99c1bc7a612a8c1f1e27d51e49e",
+    "zh:108523f3e9ebc93f7d900c51681f6edbd3f3a56b8a62b0afc31d8214892f91e0",
+    "zh:175b9bf2a00bea6ac1c73796ad77b0e00dcbbde166235017c49377d7763861d8",
+    "zh:1c8bf55b8548bbad683cd6d7bdb03e8840a00b2422dc1529ffb9892820657130",
+    "zh:22338f09bae62d5ff646de00182417f992548da534fee7d98c5d0136d4bd5d7a",
+    "zh:92de1107ec43de60612be5f6255616f16a9cf82d88df1af1c0471b81f3a82c16",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c7bfb7afea330e6d90e1466125a8cba3db1ed4043c5da52f737459c89290a6e",
+    "zh:ba59b374d477e5610674b70f5abfe0408e8f809390347372751384151440d3d0",
+    "zh:bd1c433966002f586d63cb1e3e16326991f238bc6beeb2352be36ec651917b0b",
+    "zh:ca2b4d1d02651c15261fffa4b142e45def9a22c6069353f0f663fd2046e268f8",
+    "zh:d8ed98c748f7a3f1a72277cfee9afe346aca39ab319d17402277852551d8f14a",
+    "zh:ed3d8bc89de5f35f3c5f4802ff7c749fda2e2be267f9af4a850694f099960a72",
+    "zh:f698732a4391c3f4d7079b4aaa52389da2a460cac5eed438ed688f147d603689",
+    "zh:f9f51b17f2978394954e9f6ab9ef293b8e11f1443117294ccf87f7f8212b3439",
+  ]
+}

--- a/modules/addon-pod-identity/iam.tf
+++ b/modules/addon-pod-identity/iam.tf
@@ -1,0 +1,79 @@
+locals {
+  # TODO: Do I need var.rbac_create and var.service_account_create conditions?
+  pod_identity_role_create         = var.enabled && var.rbac_create && var.service_account_create && var.pod_identity_role_create
+  pod_identity_role_name           = trim("${var.pod_identity_role_name_prefix}-${var.pod_identity_role_name}", "-")
+  pod_identity_policy_enabled      = var.pod_identity_policy_enabled && length(var.pod_identity_policy) > 0
+  pod_identity_assume_role_enabled = var.pod_identity_assume_role_enabled && length(var.pod_identity_assume_role_arns) > 0
+}
+
+data "aws_iam_policy_document" "this_assume" {
+  count = local.pod_identity_role_create && local.pod_identity_assume_role_enabled ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = var.pod_identity_assume_role_arns
+  }
+}
+
+resource "aws_iam_policy" "this" {
+  count = local.pod_identity_role_create && (local.pod_identity_policy_enabled || local.pod_identity_assume_role_enabled) ? 1 : 0
+
+  name   = local.pod_identity_role_name # tflint-ignore: aws_iam_policy_invalid_name
+  path   = "/"
+  policy = var.pod_identity_assume_role_enabled ? data.aws_iam_policy_document.this_assume[0].json : var.pod_identity_policy
+
+  tags = var.pod_identity_tags
+}
+
+data "aws_iam_policy_document" "this_pod_identity" {
+  count = local.pod_identity_role_create ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  count = local.pod_identity_role_create ? 1 : 0
+
+  name                 = local.pod_identity_role_name # tflint-ignore: aws_iam_role_invalid_name
+  assume_role_policy   = data.aws_iam_policy_document.this_pod_identity[0].json
+  permissions_boundary = var.pod_identity_permissions_boundary
+
+  tags = var.pod_identity_tags
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  count = local.pod_identity_role_create && (local.pod_identity_policy_enabled || local.pod_identity_assume_role_enabled) ? 1 : 0
+
+  role       = aws_iam_role.this[0].name
+  policy_arn = aws_iam_policy.this[0].arn
+}
+
+resource "aws_iam_role_policy_attachment" "this_additional" {
+  for_each = local.pod_identity_role_create ? var.pod_identity_additional_policies : {}
+
+  role       = aws_iam_role.this[0].name
+  policy_arn = each.value
+}
+
+resource "aws_eks_pod_identity_association" "this" {
+  count = local.pod_identity_role_create ? 1 : 0
+
+  cluster_name    = var.cluster_name
+  namespace       = var.service_account_namespace
+  service_account = var.service_account_name
+  role_arn        = aws_iam_role.this[0].arn
+}

--- a/modules/addon-pod-identity/outputs.tf
+++ b/modules/addon-pod-identity/outputs.tf
@@ -1,0 +1,9 @@
+output "pod_identity_role_enabled" {
+  description = "Whether pod identity role is enabled"
+  value       = local.pod_identity_role_create
+}
+
+output "iam_role_attributes" {
+  description = "IAM role attributes"
+  value       = try(aws_iam_role.this[0], {})
+}

--- a/modules/addon-pod-identity/variables.tf
+++ b/modules/addon-pod-identity/variables.tf
@@ -1,0 +1,96 @@
+variable "enabled" {
+  type        = bool
+  default     = true
+  description = "Set to false to prevent the module from creating any resources."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "The name of the cluster"
+}
+
+# TODO: Do I need this?
+variable "rbac_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create and use RBAC resources."
+}
+
+# TODO: Do I need this?
+variable "service_account_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create Service Account."
+}
+
+variable "service_account_name" {
+  type        = string
+  default     = ""
+  description = "The Kubernetes Service Account name. Defaults to the addon name."
+}
+
+variable "service_account_namespace" {
+  type        = string
+  default     = ""
+  description = "The Kubernetes Service Account namespace. Defaults to the addon namespace."
+}
+
+variable "pod_identity_role_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create pod identity role."
+}
+
+variable "pod_identity_role_name_prefix" {
+  type        = string
+  default     = ""
+  description = "Pod identity role name prefix. Either `pod_identity_role_name_prefix` or `pod_identity_role_name` must be set."
+}
+
+variable "pod_identity_role_name" {
+  type        = string
+  default     = ""
+  description = "Pod identity role name. The value is prefixed by `pod_identity_role_name_prefix`. Either `pod_identity_role_name` or `pod_identity_role_name_prefix` must be set."
+}
+
+variable "pod_identity_policy_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether to create IAM policy specified by `pod_identity_policy`. Mutually exclusive with `pod_identity_assume_role_enabled`."
+}
+
+variable "pod_identity_policy" {
+  type        = string
+  default     = ""
+  description = "AWS IAM policy JSON document to be attached to the pod identity role. Applied only if `pod_identity_policy_enabled` is `true`."
+}
+
+variable "pod_identity_assume_role_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether pod identity is allowed to assume role defined by `pod_identity_assume_role_arn`. Mutually exclusive with `pod_identity_policy_enabled`."
+}
+
+variable "pod_identity_assume_role_arns" {
+  type        = list(string)
+  default     = []
+  description = "List of ARNs assumable by the pod identity role. Applied only if `pod_identity_assume_role_enabled` is `true`."
+}
+
+variable "pod_identity_permissions_boundary" {
+  type        = string
+  default     = null
+  description = "ARN of the policy that is used to set the permissions boundary for the pod identity role."
+}
+
+variable "pod_identity_additional_policies" {
+  type        = map(string)
+  default     = {}
+  description = "Map of the additional policies to be attached to pod identity role. Where key is arbitrary id and value is policy ARN."
+}
+
+variable "pod_identity_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Pod identity resources tags."
+}

--- a/modules/addon-pod-identity/versions.tf
+++ b/modules/addon-pod-identity/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}

--- a/scripts/sync-variables.py
+++ b/scripts/sync-variables.py
@@ -7,6 +7,14 @@ import argparse
 import logging
 from jinja2 import Environment, FileSystemLoader
 
+# TODO: Load variable names dynamically from variables-eks.tf
+excluded_variables = [
+  "rbac_create",
+  "service_account_create",
+  "service_account_name",
+  "service_account_namespace",
+]
+
 def filter_terraform_type(value):
     # Currently there is a limition in handling Terraform complex types
     #   https://github.com/amplify-education/python-hcl2/issues/179
@@ -62,6 +70,7 @@ def main(args):
     log = get_logger(args)
     log.info("Syncing variables from Terraform modules...")
     log.warning("Terraform variable complex types are NOT supported!")
+    log.info("Excluded variables: %s", excluded_variables)
 
     template = get_template()
 
@@ -79,7 +88,14 @@ def main(args):
             log.info("Reading variables from `%s`", source)
 
             variables = hcl2.load(f).get('variable')
+
             log.info("Collected variables: %d", len(variables))
+            log.debug(variables)
+
+            # Remove excluded variables
+            variables[:] = [item for item in variables if list(item.keys())[0] not in excluded_variables]
+
+            log.info("Filtered variables: %d", len(variables))
             log.debug(variables)
 
             with open(target, "w") as f:

--- a/variables-addon-irsa.tf
+++ b/variables-addon-irsa.tf
@@ -12,30 +12,6 @@ variable "cluster_identity_oidc_issuer_arn" {
   description = "The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a Service Account (required)."
 }
 
-variable "rbac_create" {
-  type        = bool
-  default     = null
-  description = "Whether to create and use RBAC resources. Defaults to `true`."
-}
-
-variable "service_account_create" {
-  type        = bool
-  default     = null
-  description = "Whether to create Service Account. Defaults to `true`."
-}
-
-variable "service_account_name" {
-  type        = string
-  default     = null
-  description = "The Kubernetes Service Account name. Defaults to the addon name. Defaults to `\"\"`."
-}
-
-variable "service_account_namespace" {
-  type        = string
-  default     = null
-  description = "The Kubernetes Service Account namespace. Defaults to the addon namespace. Defaults to `\"\"`."
-}
-
 variable "irsa_role_create" {
   type        = bool
   default     = null

--- a/variables-addon-pod-identity.tf
+++ b/variables-addon-pod-identity.tf
@@ -1,0 +1,92 @@
+# IMPORTANT: This file is synced with the "terraform-aws-eks-universal-addon" module. Any changes to this file might be overwritten upon the next release of that module.
+
+variable "cluster_name" {
+  type        = string
+  description = "The name of the cluster"
+}
+
+# TODO: Do I need this?
+variable "pi_rbac_create" {
+  type        = bool
+  default     = null
+  description = "Whether to create and use RBAC resources. Defaults to `true`."
+}
+
+# TODO: Do I need this?
+variable "pi_service_account_create" {
+  type        = bool
+  default     = null
+  description = "Whether to create Service Account. Defaults to `true`."
+}
+
+variable "pi_service_account_name" {
+  type        = string
+  default     = null
+  description = "The Kubernetes Service Account name. Defaults to the addon name. Defaults to `\"\"`."
+}
+
+variable "pi_service_account_namespace" {
+  type        = string
+  default     = null
+  description = "The Kubernetes Service Account namespace. Defaults to the addon namespace. Defaults to `\"\"`."
+}
+
+variable "pod_identity_role_create" {
+  type        = bool
+  default     = null
+  description = "Whether to create pod identity role and annotate Service Account. Defaults to `true`."
+}
+
+variable "pod_identity_role_name_prefix" {
+  type        = string
+  default     = null
+  description = "Pod identity role name prefix. Either `pod_identity_role_name_prefix` or `pod_identity_role_name` must be set. Defaults to `\"\"`."
+}
+
+variable "pod_identity_role_name" {
+  type        = string
+  default     = null
+  description = "Pod identity role name. The value is prefixed by `pod_identity_role_name_prefix`. Either `pod_identity_role_name` or `pod_identity_role_name_prefix` must be set. Defaults to `\"\"`."
+}
+
+variable "pod_identity_policy_enabled" {
+  type        = bool
+  default     = null
+  description = "Whether to create IAM policy specified by `pod_identity_policy`. Mutually exclusive with `pod_identity_assume_role_enabled`. Defaults to `false`."
+}
+
+variable "pod_identity_policy" {
+  type        = string
+  default     = null
+  description = "AWS IAM policy JSON document to be attached to the pod identity role. Applied only if `pod_identity_policy_enabled` is `true`. Defaults to `\"\"`."
+}
+
+variable "pod_identity_assume_role_enabled" {
+  type        = bool
+  default     = null
+  description = "Whether pod identity is allowed to assume role defined by `pod_identity_assume_role_arn`. Mutually exclusive with `pod_identity_policy_enabled`. Defaults to `false`."
+}
+
+variable "pod_identity_assume_role_arns" {
+  type        = list(string)
+  default     = null
+  description = "List of ARNs assumable by the pod identity role. Applied only if `pod_identity_assume_role_enabled` is `true`. Defaults to `[]`."
+}
+
+variable "pod_identity_permissions_boundary" {
+  type        = string
+  default     = null
+  description = "ARN of the policy that is used to set the permissions boundary for the pod identity role. Defaults to `null`."
+}
+
+variable "pod_identity_additional_policies" {
+  type        = map(string)
+  default     = null
+  description = "Map of the additional policies to be attached to pod identity role. Where key is arbitrary id and value is policy ARN. Defaults to `{}`."
+}
+
+variable "pod_identity_tags" {
+  type        = map(string)
+  default     = null
+  description = "Pod identity resources tags. Defaults to `{}`."
+}

--- a/variables-addon-pod-identity.tf
+++ b/variables-addon-pod-identity.tf
@@ -5,32 +5,6 @@ variable "cluster_name" {
   description = "The name of the cluster"
 }
 
-# TODO: Do I need this?
-variable "pi_rbac_create" {
-  type        = bool
-  default     = null
-  description = "Whether to create and use RBAC resources. Defaults to `true`."
-}
-
-# TODO: Do I need this?
-variable "pi_service_account_create" {
-  type        = bool
-  default     = null
-  description = "Whether to create Service Account. Defaults to `true`."
-}
-
-variable "pi_service_account_name" {
-  type        = string
-  default     = null
-  description = "The Kubernetes Service Account name. Defaults to the addon name. Defaults to `\"\"`."
-}
-
-variable "pi_service_account_namespace" {
-  type        = string
-  default     = null
-  description = "The Kubernetes Service Account namespace. Defaults to the addon namespace. Defaults to `\"\"`."
-}
-
 variable "pod_identity_role_create" {
   type        = bool
   default     = null

--- a/variables-eks.tf
+++ b/variables-eks.tf
@@ -1,0 +1,25 @@
+# IMPORTANT: This file is synced with the "terraform-aws-eks-universal-addon" module. Any changes to this file might be overwritten upon the next release of that module.
+
+variable "rbac_create" {
+  type        = bool
+  default     = null
+  description = "Whether to create and use RBAC resources. Defaults to `true`."
+}
+
+variable "service_account_create" {
+  type        = bool
+  default     = null
+  description = "Whether to create Service Account. Defaults to `true`."
+}
+
+variable "service_account_name" {
+  type        = string
+  default     = null
+  description = "The Kubernetes Service Account name. Defaults to the addon name. Defaults to `\"\"`."
+}
+
+variable "service_account_namespace" {
+  type        = string
+  default     = null
+  description = "The Kubernetes Service Account namespace. Defaults to the addon namespace. Defaults to `\"\"`."
+}


### PR DESCRIPTION
# Description

Adding new module for handling pod identity. Reason is simple - we want to migrate terraform-aws-eks-load-balancer-controller to universal addon. Addon template has support for pod identity, but universal addon does not. Here it comes.

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

Not yet.
