### PR TITLE
feat(ci): add zizmor to pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
@@ -63,3 +65,5 @@ jobs:
 
       - name: Run pre-commit
         run: pre-commit run --show-diff-on-failure --color=always --all-files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required for zizmor

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -16,7 +16,6 @@ jobs:
         with:
           persist-credentials: false
 
-
       - name: Generate GitHub App token
         id: lara-renovate-app-token
         uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
 
       - name: Generate GitHub App token
         id: lara-renovate-app-token

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ steps.template-sync-app-token.outputs.token }} # needed for private repositories
+          persist-credentials: false
 
       - name: Sync universal-addon template
         uses: AndreasAugustin/actions-template-sync@bcb94410a4f1dffdfe5eaabc8234c3b8e76ebc5b # v2.5.1

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Extract Terraform min/max versions
         id: terraform-min-max
@@ -39,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # v5.0.0 # pragma: allowlist secret
     hooks:
       - id: trailing-whitespace
         args: ["--markdown-linebreak-ext=md"]
@@ -11,7 +11,7 @@ repos:
       - id: end-of-file-fixer
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.96.3
+    rev: 55d0143972eec4905fdaea2f444f1e88218f9dce # v1.96.3 # pragma: allowlist secret
     hooks:
       - id: terraform_validate
       - id: terraform_fmt
@@ -26,17 +26,22 @@ repos:
           - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
       - id: terraform_checkov
         args:
-          - "--args=--quiet --skip-check CKV_TF_1" #CKV_TF_1: "Ensure Terraform module sources use a commit hash"
+          - "--args=--quiet --skip-check CKV_TF_1" # CKV_TF_1: "Ensure Terraform module sources use a commit hash"
       - id: terraform_docs
         args:
           - "--args=--config=.terraform-docs.yml"
 
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
+    rev: 01886c8a910c64595c47f186ca1ffc0b77fa5458 # v1.5.0 # pragma: allowlist secret
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
         exclude: terraform.tfstate
+
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: 07a06156e31897fbb5ba0e22a961e8e3c2a0677b # v.1.16.0 # pragma: allowlist secret
+    hooks:
+      - id: zizmor
 
   - repo: local
     hooks:

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "enabledManagers": [
     "asdf",
     "pip_requirements",
+    "pre-commit",
     "github-actions",
     "custom.regex"
   ],
@@ -36,6 +37,9 @@
     }
   ],
   "pinDigests": true,
+  "pre-commit": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

This pull request introduces several updates to GitHub Actions workflows, pre-commit hooks, and the `renovate.json` configuration. The most notable changes include disabling credential persistence in `actions/checkout` steps across multiple workflows, adding a new pre-commit hook for `zizmor`, and enabling Renovate to manage pre-commit hooks.

### GitHub Actions Workflow Updates:
* [`.github/workflows/pre-commit.yaml`](diffhunk://#diff-3c0d80ea54e617ba55ba031dda6fc983852272f93775375ce402a66a03560548R27-R28): Disabled credential persistence in the `actions/checkout` step and added the `GH_TOKEN` environment variable for the `Run pre-commit` step. [[1]](diffhunk://#diff-3c0d80ea54e617ba55ba031dda6fc983852272f93775375ce402a66a03560548R27-R28) [[2]](diffhunk://#diff-3c0d80ea54e617ba55ba031dda6fc983852272f93775375ce402a66a03560548R68-R69)
* `.github/workflows/renovate.yaml`, `.github/workflows/template-sync.yaml`, `.github/workflows/validate.yaml`: Disabled credential persistence in the `actions/checkout` step to enhance security. [[1]](diffhunk://#diff-f87681f1c7db60655a75838d0610544d4b75e26c6909a97b97f5ec4aa323c7aaR16-R17) [[2]](diffhunk://#diff-a0603799065ac5db0aecc95ec0ca015f27b38006c865b95684941dade0f55ce8R36) [[3]](diffhunk://#diff-9237aa56078dfbd8fcac3198563f306ada599aabaa43aca884905129779c5846R21-R22) [[4]](diffhunk://#diff-9237aa56078dfbd8fcac3198563f306ada599aabaa43aca884905129779c5846R44-R45)

### Pre-commit Hook Updates:
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L3-R3): Updated existing hooks to use specific commit SHAs for versioning, added a new `zizmor` hook for enhanced functionality, and ensured compliance with allowlist secrets. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L3-R3) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L14-R14) [[3]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L35-R45)

### Renovate Configuration Updates:
* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R7): Enabled the `pre-commit` manager and added configuration for managing pre-commit hooks. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R7) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R39-R41)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->

https://github.com/lablabs/terraform-aws-eks-universal-addon/actions/runs/14710739345