### PR TITLE
fix(universal-addon): fix addon_irsa_policies issue due to try

### DIFF
--- a/addon-irsa.tf
+++ b/addon-irsa.tf
@@ -23,7 +23,7 @@ module "addon-irsa" {
   irsa_assume_role_enabled  = var.irsa_assume_role_enabled != null ? var.irsa_assume_role_enabled : try(each.value.irsa_assume_role_enabled, false)
   irsa_assume_role_arns     = var.irsa_assume_role_arns != null ? var.irsa_assume_role_arns : try(each.value.irsa_assume_role_arns, [])
   irsa_permissions_boundary = var.irsa_permissions_boundary != null ? var.irsa_permissions_boundary : try(each.value.irsa_permissions_boundary, null)
-  irsa_additional_policies  = var.irsa_additional_policies != null ? var.irsa_additional_policies : try(each.value.irsa_additional_policies, tomap({}))
+  irsa_additional_policies  = var.irsa_additional_policies != null ? var.irsa_additional_policies : lookup(each.value, "irsa_additional_policies", tomap({}))
 
   irsa_assume_role_policy_condition_test   = var.irsa_assume_role_policy_condition_test != null ? var.irsa_assume_role_policy_condition_test : try(each.value.irsa_assume_role_policy_condition_test, "StringEquals")
   irsa_assume_role_policy_condition_values = var.irsa_assume_role_policy_condition_values != null ? var.irsa_assume_role_policy_condition_values : try(each.value.irsa_assume_role_policy_condition_values, [])

--- a/addon-oidc.tf
+++ b/addon-oidc.tf
@@ -16,7 +16,7 @@ module "addon-oidc" {
   oidc_assume_role_enabled                   = var.oidc_assume_role_enabled != null ? var.oidc_assume_role_enabled : try(each.value.oidc_assume_role_enabled, false)
   oidc_assume_role_arns                      = var.oidc_assume_role_arns != null ? var.oidc_assume_role_arns : try(each.value.oidc_assume_role_arns, [])
   oidc_permissions_boundary                  = var.oidc_permissions_boundary != null ? var.oidc_permissions_boundary : try(each.value.oidc_permissions_boundary, null)
-  oidc_additional_policies                   = var.oidc_additional_policies != null ? var.oidc_additional_policies : try(each.value.oidc_additional_policies, tomap({}))
+  oidc_additional_policies                   = var.oidc_additional_policies != null ? var.oidc_additional_policies : lookup(each.value, "oidc_additional_policies", tomap({}))
   oidc_openid_client_ids                     = var.oidc_openid_client_ids != null ? var.oidc_openid_client_ids : try(each.value.oidc_openid_client_ids, [])
   oidc_openid_provider_url                   = var.oidc_openid_provider_url != null ? var.oidc_openid_provider_url : try(each.value.oidc_openid_provider_url, "")
   oidc_openid_thumbprints                    = var.oidc_openid_thumbprints != null ? var.oidc_openid_thumbprints : try(each.value.oidc_openid_thumbprints, [])


### PR DESCRIPTION
# Description
We are adding server_irsa_additional_policies in argo_workflow module, leveraging new universal addon format (also applies to controller and workflow sections) via local variable, as we may need separate extra policies for any of them:
```
  addon_irsa = {
    "${local.addon.name}-server" = {
      service_account_name = "${local.addon.name}-server"
      irsa_role_create = var.server_irsa_role_create != null ? var.server_irsa_role_create : true
      irsa_role_name = "${local.addon.name}-serv-irsa" # Max length of rolename was reached, using shortened version
      irsa_additional_policies = length(var.server_irsa_additional_policies) != 0 ? var.server_irsa_additional_policies : tomap({})
    }
```
The for_each in module is failing, as it cannot determine in advance the value of that variable and getting following error:
```
│ Error: Invalid for_each argument
│
│   on .terraform/modules/argo-workflows.addon-irsa/modules/addon-irsa/iam.tf line 71, in resource "aws_iam_role_policy_attachment" "this_additional":
│   71:   for_each = local.irsa_role_create ? var.irsa_additional_policies : {}
│     ├────────────────
│     │ local.irsa_role_create is true
│     │ var.irsa_additional_policies is a map of string, known only after apply
│
│ The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the
│ instances of this resource.
│
│ When working with unknown values in for_each, it's better to define the map keys statically in your configuration and place apply-time results only in the map values.
│
│ Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to fully converge.
```

Issue was caused by try clause in addon-irsa.tf 

## Type of change

- [X] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?
in Dev environment with local module changes in argo_workflows module
