### PR TITLE
fix(modules): use deep merge only for ArgoCD App specv

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -70,6 +70,10 @@ module "addon_installation_argo_helm" {
   cluster_identity_oidc_issuer     = module.eks_cluster.eks_cluster_identity_oidc_issuer
   cluster_identity_oidc_issuer_arn = module.eks_cluster.eks_cluster_identity_oidc_issuer_arn
 
+  values = yamlencode({
+    # insert sample values here
+  })
+
   argo_sync_policy = {
     automated   = {}
     syncOptions = ["CreateNamespace=true"]

--- a/modules/addon-irsa/outputs.tf
+++ b/modules/addon-irsa/outputs.tf
@@ -1,3 +1,18 @@
+output "rbac_create" {
+  description = "Whether RBAC resources are created and used"
+  value       = var.rbac_create
+}
+
+output "service_account_create" {
+  description = "Whether Service Account is created"
+  value       = var.service_account_create
+}
+
+output "service_account_name" {
+  description = "Service Account name"
+  value       = var.service_account_name
+}
+
 output "irsa_role_enabled" {
   description = "Whether IRSA role is enabled"
   value       = local.irsa_role_create

--- a/modules/addon-irsa/variables.tf
+++ b/modules/addon-irsa/variables.tf
@@ -36,14 +36,14 @@ variable "service_account_create" {
 variable "service_account_name" {
   type        = string
   default     = ""
-  description = "The Kubernetes Service Account name. Defaults to the addon name."
+  description = "The Kubernetes Service Account name."
   nullable    = false
 }
 
 variable "service_account_namespace" {
   type        = string
   default     = ""
-  description = "The Kubernetes Service Account namespace. Defaults to the addon namespace."
+  description = "The Kubernetes Service Account namespace."
   nullable    = false
 }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

This pull request introduces enhancements to the Helm addon installation and IRSA (IAM Roles for Service Accounts) module, focusing on configurability, output improvements, and resource management. The most significant changes involve adding new outputs for better visibility, refining variable descriptions, and improving the handling of Kubernetes manifests.

### Enhancements to Helm addon installation:
* Added a `values` block in `examples/basic/main.tf` to encode sample Helm chart values using `yamlencode`, improving configurability for the addon installation.

### Improvements to IRSA module:
* Added new outputs (`rbac_create`, `service_account_create`, and `service_account_name`) to `modules/addon-irsa/outputs.tf` for better visibility into RBAC and service account configurations.
* Updated descriptions for `service_account_name` and `service_account_namespace` variables in `modules/addon-irsa/variables.tf`, removing references to default behavior for clarity.

### Kubernetes manifest handling:
* Refactored `modules/addon/argo.tf` to improve the merging of Argo application specifications. Introduced a new `utils_deep_merge_yaml` data block (`argo_application_spec`) for deeper merging of YAML configurations and updated the `kubernetes_manifest` resource to handle CRD validation during the plan phase. [[1]](diffhunk://#diff-3bb9b8e0a43f60bf5118e3fe9137c45b42bea1096e30b32eb418a7890be20cc2L52-R71) [[2]](diffhunk://#diff-3bb9b8e0a43f60bf5118e3fe9137c45b42bea1096e30b32eb418a7890be20cc2L66-L87)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->

- Installation of addon in a cycle (for_each)
- Installation of addon without a cycle
- Installation of addon with spec deep merge