### PR TITLE
fix(universal-addon): validation for argo_source_type 

### DIFF
--- a/modules/addon/variables.tf
+++ b/modules/addon/variables.tf
@@ -137,7 +137,7 @@ variable "argo_source_type" {
   nullable    = false
 
   validation {
-    condition     = contains(["helm", "kustomize", "directory"], var.argo_source_type)
+    condition     = contains(["helm", "kustomize", "directory", "helm-directory"], var.argo_source_type)
     error_message = "Source type must be either `helm`, `kustomize`, or `directory`."
   }
 }


### PR DESCRIPTION

# Description

Validation inside variables.tf was not handled to support new helm-directory

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?
In local module
