### PR TITLE
chore(workflows): update ASDF version

### DIFF
--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -1,18 +1,11 @@
-name: pre-commit
+name: Cache Warmup
 
 on:
-  workflow_dispatch:
-  pull_request:
+  push:
     branches:
-      - main
-      - master
+      - main # caches from the main branch are shared with all other branches and pull requests
 
-permissions:
-  contents: read
-
-concurrency:
-  group: pre-commit-${{ github.ref }}
-  cancel-in-progress: false
+permissions: {}
 
 env:
   # renovate: datasource=github-releases depName=asdf-vm/asdf
@@ -42,20 +35,11 @@ jobs:
             ~/.asdf/plugins
             ~/.asdf/shims
             ~/.cache/pip
-          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
-          restore-keys: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}-
+          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}-warmup
+          restore-keys: ${{ runner.os }}-asdf-
 
       - name: Install ASDF
         uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302 # v4.0.0
         if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
         with:
           asdf_version: ${{ env.ASDF_VERSION }}
-
-      - name: Reshim installed ASDF tools
-        shell: bash
-        run: asdf reshim
-
-      - name: Run pre-commit
-        run: pre-commit run --show-diff-on-failure --color=always --all-files
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required for zizmor


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

This pull request introduces a new GitHub Actions workflow for cache warmup and updates the existing `pre-commit` workflow to improve caching and upgrade dependencies. The most important changes include the addition of the `cache-warmup.yaml` workflow, updates to the `ASDF` version and related actions, and improvements to caching behavior in the `pre-commit` workflow.

### New Cache Warmup Workflow:
* Added a new workflow file `.github/workflows/cache-warmup.yaml` to pre-warm caches for ASDF and pip dependencies. This workflow runs on pushes to the `main` branch and uses updated versions of the `actions/checkout`, `asdf-vm/actions/setup`, and `actions/cache` actions.

### Updates to the `pre-commit` Workflow:
* Updated `ASDF_VERSION` from `v0.15.0` to `v0.18.0` for compatibility with newer ASDF features.
* Upgraded the `asdf-vm/actions/setup` and `asdf-vm/actions/install` actions from `v3.0.2` to `v4.0.0` for improved functionality and compatibility. [[1]](diffhunk://#diff-3c0d80ea54e617ba55ba031dda6fc983852272f93775375ce402a66a03560548L31-R33) [[2]](diffhunk://#diff-3c0d80ea54e617ba55ba031dda6fc983852272f93775375ce402a66a03560548R44-L62)
* Enhanced caching behavior by adding the `~/.cache/pip` directory to the cache path and refining the `restore-keys` logic for better cache reuse.
* Removed the redundant "Cache pip" step, as pip caching is now integrated into the ASDF cache configuration.

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)